### PR TITLE
feat: restrict claimable amount after slashing

### DIFF
--- a/src/Accounting.sol
+++ b/src/Accounting.sol
@@ -427,6 +427,8 @@ contract Accounting is
         uint256 cumulativeFeeShares,
         bytes32[] calldata rewardsProof
     ) external view returns (uint256 claimableShares) {
+        if (_isBondClaimRestricted(nodeOperatorId)) return 0;
+
         uint256 feesToDistribute = FEE_DISTRIBUTOR.getFeesToDistribute(
             nodeOperatorId,
             cumulativeFeeShares,
@@ -540,9 +542,18 @@ contract Accounting is
     ///      Does not subtract pending split transfers, so in rare cases (e.g. locked bond or bond debt)
     ///      may overestimate the operator-receivable amount.
     ///      Off-chain integrations should account for `getPendingSharesToSplit`.
+    /// @dev Returns zero while bond claims are restricted, blocking fee split payouts as well.
     function _getClaimableBondShares(uint256 nodeOperatorId) internal view returns (uint256) {
+        if (_isBondClaimRestricted(nodeOperatorId)) return 0;
+
         (uint256 currentShares, uint256 requiredShares) = getBondSummaryShares(nodeOperatorId);
         return Math.saturatingSub(currentShares, requiredShares);
+    }
+
+    /// @dev Returns true until all the slashed validators are reported as withdrawn. The uncovered losses remain
+    ///      as the bond debt, which is a part of the required bond.
+    function _isBondClaimRestricted(uint256 nodeOperatorId) internal view returns (bool) {
+        return MODULE.getNodeOperatorUnresolvedSlashedValidators(nodeOperatorId) != 0;
     }
 
     function _getRequiredBond(

--- a/src/Accounting.sol
+++ b/src/Accounting.sol
@@ -422,6 +422,11 @@ contract Accounting is
     }
 
     /// @inheritdoc IAccounting
+    function isBondClaimRestricted(uint256 nodeOperatorId) external view returns (bool) {
+        return _isBondClaimRestricted(nodeOperatorId);
+    }
+
+    /// @inheritdoc IAccounting
     function getClaimableRewardsAndBondShares(
         uint256 nodeOperatorId,
         uint256 cumulativeFeeShares,

--- a/src/abstract/BaseModule.sol
+++ b/src/abstract/BaseModule.sol
@@ -342,6 +342,12 @@ abstract contract BaseModule is
         uint256 pointer = KeyPointerLib.keyPointer(nodeOperatorId, keyIndex);
         if ($.isValidatorSlashed[pointer]) revert ValidatorSlashingAlreadyReported();
         $.isValidatorSlashed[pointer] = true;
+        // A slashing reported after the withdrawal of the key has nothing left to resolve.
+        if (!$.isValidatorWithdrawn[pointer]) {
+            unchecked {
+                ++no.unresolvedSlashedValidators;
+            }
+        }
 
         bytes memory pubkey = SigningKeys.loadKeys(nodeOperatorId, keyIndex, 1);
         emit ValidatorSlashingReported(nodeOperatorId, keyIndex, pubkey);
@@ -517,6 +523,11 @@ abstract contract BaseModule is
         unchecked {
             return no.totalAddedKeys - no.totalWithdrawnKeys;
         }
+    }
+
+    /// @inheritdoc IBaseModule
+    function getNodeOperatorUnresolvedSlashedValidators(uint256 nodeOperatorId) external view returns (uint256) {
+        return _baseStorage().nodeOperators[nodeOperatorId].unresolvedSlashedValidators;
     }
 
     /// @inheritdoc IBaseModule

--- a/src/abstract/BaseModule.sol
+++ b/src/abstract/BaseModule.sol
@@ -344,10 +344,12 @@ abstract contract BaseModule is
         $.isValidatorSlashed[pointer] = true;
         // A slashing reported after the withdrawal of the key has nothing left to resolve.
         if (!$.isValidatorWithdrawn[pointer]) {
+            uint256 unresolved;
             unchecked {
-                ++no.unresolvedSlashedValidators;
+                unresolved = $.unresolvedSlashedValidators[nodeOperatorId] + 1;
             }
-            emit UnresolvedSlashedValidatorsCountChanged(nodeOperatorId, no.unresolvedSlashedValidators);
+            $.unresolvedSlashedValidators[nodeOperatorId] = unresolved;
+            emit UnresolvedSlashedValidatorsCountChanged(nodeOperatorId, unresolved);
         }
 
         bytes memory pubkey = SigningKeys.loadKeys(nodeOperatorId, keyIndex, 1);
@@ -528,7 +530,7 @@ abstract contract BaseModule is
 
     /// @inheritdoc IBaseModule
     function getNodeOperatorUnresolvedSlashedValidators(uint256 nodeOperatorId) external view returns (uint256) {
-        return _baseStorage().nodeOperators[nodeOperatorId].unresolvedSlashedValidators;
+        return _baseStorage().unresolvedSlashedValidators[nodeOperatorId];
     }
 
     /// @inheritdoc IBaseModule

--- a/src/abstract/BaseModule.sol
+++ b/src/abstract/BaseModule.sol
@@ -347,6 +347,7 @@ abstract contract BaseModule is
             unchecked {
                 ++no.unresolvedSlashedValidators;
             }
+            emit UnresolvedSlashedValidatorsCountChanged(nodeOperatorId, no.unresolvedSlashedValidators);
         }
 
         bytes memory pubkey = SigningKeys.loadKeys(nodeOperatorId, keyIndex, 1);

--- a/src/abstract/ModuleLinearStorage.sol
+++ b/src/abstract/ModuleLinearStorage.sol
@@ -30,6 +30,8 @@ abstract contract ModuleLinearStorage {
         /* 10 */ mapping(uint256 nodeOperatorId => uint256 extraBalance) operatorBalances;
         /* 11 */ uint256 totalExtraStake;
         /* 12 */ mapping(uint256 nodeOperatorId => uint256 createdAt) nodeOperatorCreatedAt;
+        /// @dev Slashed validators of the Node Operator whose withdrawal losses are not processed yet.
+        /* 13 */ mapping(uint256 nodeOperatorId => uint256) unresolvedSlashedValidators;
     }
 
     function _baseStorage() internal pure returns (BaseModuleStorage storage $) {

--- a/src/interfaces/IAccounting.sol
+++ b/src/interfaces/IAccounting.sol
@@ -197,6 +197,11 @@ interface IAccounting is IBondCore, IBondCurve, IBondLock, IFeeSplits, IAssetRec
     /// @return Current claimable bond in stETH shares
     function getClaimableBondShares(uint256 nodeOperatorId) external view returns (uint256);
 
+    /// @notice Check whether bond claims of the given Node Operator are restricted due to unresolved slashings
+    /// @param nodeOperatorId ID of the Node Operator
+    /// @return True if the Node Operator has slashed validators with unreported withdrawals
+    function isBondClaimRestricted(uint256 nodeOperatorId) external view returns (bool);
+
     /// @notice Get current claimable bond in stETH shares for the given Node Operator
     ///         Includes potential rewards distributed by the Fee Distributor
     /// @dev Returns zero while the Node Operator's bond claims are restricted, see `getClaimableBondShares`

--- a/src/interfaces/IAccounting.sol
+++ b/src/interfaces/IAccounting.sol
@@ -191,12 +191,15 @@ interface IAccounting is IBondCore, IBondCurve, IBondLock, IFeeSplits, IAssetRec
     function getBondSummaryShares(uint256 nodeOperatorId) external view returns (uint256 current, uint256 required);
 
     /// @notice Get current claimable bond in stETH shares for the given Node Operator
+    /// @dev Returns zero while the Node Operator has slashed validators with unreported withdrawals. The uncovered
+    ///      losses remain as the bond debt, keeping the claimable amount at zero until compensated.
     /// @param nodeOperatorId ID of the Node Operator
     /// @return Current claimable bond in stETH shares
     function getClaimableBondShares(uint256 nodeOperatorId) external view returns (uint256);
 
     /// @notice Get current claimable bond in stETH shares for the given Node Operator
     ///         Includes potential rewards distributed by the Fee Distributor
+    /// @dev Returns zero while the Node Operator's bond claims are restricted, see `getClaimableBondShares`
     /// @param nodeOperatorId ID of the Node Operator
     /// @param cumulativeFeeShares Cumulative fee stETH shares for the Node Operator
     /// @param rewardsProof Merkle proof of the rewards
@@ -267,6 +270,7 @@ interface IAccounting is IBondCore, IBondCurve, IBondLock, IFeeSplits, IAssetRec
     /// @return shares Amount of stETH shares claimed
     /// @dev It's impossible to use single-leaf proof via this method, so this case should be treated carefully by
     /// off-chain tooling, e.g. to make sure a tree has at least 2 leaves.
+    /// @dev Claims nothing while bond claims are restricted, see `getClaimableBondShares`. Rewards are still pulled.
     function claimRewardsStETH(
         uint256 nodeOperatorId,
         uint256 stETHAmount,
@@ -283,6 +287,7 @@ interface IAccounting is IBondCore, IBondCurve, IBondLock, IFeeSplits, IAssetRec
     /// @return claimedWstETHAmount Amount of wstETH claimed
     /// @dev It's impossible to use single-leaf proof via this method, so this case should be treated carefully by
     /// off-chain tooling, e.g. to make sure a tree has at least 2 leaves.
+    /// @dev Claims nothing while bond claims are restricted, see `getClaimableBondShares`. Rewards are still pulled.
     function claimRewardsWstETH(
         uint256 nodeOperatorId,
         uint256 wstETHAmount,
@@ -300,6 +305,7 @@ interface IAccounting is IBondCore, IBondCurve, IBondLock, IFeeSplits, IAssetRec
     /// @return requestId Withdrawal NFT ID
     /// @dev It's impossible to use single-leaf proof via this method, so this case should be treated carefully by
     /// off-chain tooling, e.g. to make sure a tree has at least 2 leaves.
+    /// @dev Claims nothing while bond claims are restricted, see `getClaimableBondShares`. Rewards are still pulled.
     function claimRewardsUnstETH(
         uint256 nodeOperatorId,
         uint256 stETHAmount,

--- a/src/interfaces/IBaseModule.sol
+++ b/src/interfaces/IBaseModule.sol
@@ -85,6 +85,7 @@ interface IBaseModule is IStakingModule, IAccessControlEnumerable, IAssetRecover
     event TotalWithdrawnValidatorsRebuilt(uint256 totalWithdrawnValidators);
     event NodeOperatorBalanceUpdated(uint256 indexed operatorId, uint256 balanceWei);
     event ValidatorSlashingReported(uint256 indexed nodeOperatorId, uint256 keyIndex, bytes pubkey);
+    event UnresolvedSlashedValidatorsCountChanged(uint256 indexed nodeOperatorId, uint256 count);
     event KeyAllocatedBalanceChanged(uint256 indexed nodeOperatorId, uint256 indexed keyIndex, uint256 newTotal);
     event KeyConfirmedBalanceChanged(uint256 indexed nodeOperatorId, uint256 indexed keyIndex, uint256 newBalance);
     event KeyRemovalChargeApplied(uint256 indexed nodeOperatorId);

--- a/src/interfaces/IBaseModule.sol
+++ b/src/interfaces/IBaseModule.sol
@@ -24,6 +24,7 @@ struct NodeOperator {
     /* 1 */ uint32 depositableValidatorsCount; // @dev any value
     /* 1 */ uint32 targetLimit;
     /* 1 */ uint8 targetLimitMode;
+    /* 1 */ uint24 unresolvedSlashedValidators; // @dev slashed validators whose withdrawal losses are not processed
     /* 2 */ uint32 totalExitedKeys; // @dev only increased except for the unsafe updates
     /* 2 */ uint32 enqueuedCount; // Tracks how many places are occupied by the node operator's keys in the queue.
     /* 2 */ address managerAddress;
@@ -392,6 +393,13 @@ interface IBaseModule is IStakingModule, IAccessControlEnumerable, IAssetRecover
     /// @return Non-withdrawn keys count
     function getNodeOperatorNonWithdrawnKeys(uint256 nodeOperatorId) external view returns (uint256);
 
+    /// @notice Get the number of slashed validators whose withdrawal losses have not been processed yet
+    /// @dev Increased on a slashing report and decreased on the withdrawal report of the slashed validator.
+    ///      A non-zero value restricts bond claims, see `IAccounting.getClaimableBondShares`.
+    /// @param nodeOperatorId ID of the Node Operator
+    /// @return Unresolved slashed validators count
+    function getNodeOperatorUnresolvedSlashedValidators(uint256 nodeOperatorId) external view returns (uint256);
+
     /// @notice Returns tracked operator balance (active validator base stake plus tracked extra).
     /// @dev The tracked extra is intentionally monotonic for active validators and is reduced on withdrawal reporting,
     ///      not on intermediate balance decreases, so the value serves both top-up allocation and withdrawal penalty accounting.
@@ -424,6 +432,7 @@ interface IBaseModule is IStakingModule, IAccessControlEnumerable, IAssetRecover
 
     /// @notice Report Node Operator's key as slashed.
     /// @notice Called by `Verifier` contract. See `Verifier.processSlashedProof`.
+    /// @dev A slashing reported for an already withdrawn key does not restrict the bond claims.
     /// @param nodeOperatorId The ID of the Node Operator
     /// @param keyIndex Index of the key in the Node Operator's keys storage
     function reportValidatorSlashing(uint256 nodeOperatorId, uint256 keyIndex) external;

--- a/src/interfaces/IBaseModule.sol
+++ b/src/interfaces/IBaseModule.sol
@@ -24,7 +24,6 @@ struct NodeOperator {
     /* 1 */ uint32 depositableValidatorsCount; // @dev any value
     /* 1 */ uint32 targetLimit;
     /* 1 */ uint8 targetLimitMode;
-    /* 1 */ uint24 unresolvedSlashedValidators; // @dev slashed validators whose withdrawal losses are not processed
     /* 2 */ uint32 totalExitedKeys; // @dev only increased except for the unsafe updates
     /* 2 */ uint32 enqueuedCount; // Tracks how many places are occupied by the node operator's keys in the queue.
     /* 2 */ address managerAddress;

--- a/src/lib/WithdrawnValidatorLib.sol
+++ b/src/lib/WithdrawnValidatorLib.sol
@@ -62,6 +62,7 @@ library WithdrawnValidatorLib {
             if ($.isValidatorSlashed[pointer]) {
                 uint256 unresolved = $.unresolvedSlashedValidators[info.nodeOperatorId];
                 // The decrement is saturating: a slashing reported before the counter was introduced is not counted.
+                // NOTE: The counter is per Node Operator, so such a legacy slashing resolves a newer one instead.
                 if (unresolved != 0) {
                     unchecked {
                         --unresolved;

--- a/src/lib/WithdrawnValidatorLib.sol
+++ b/src/lib/WithdrawnValidatorLib.sol
@@ -65,6 +65,10 @@ library WithdrawnValidatorLib {
                 unchecked {
                     --no.unresolvedSlashedValidators;
                 }
+                emit IBaseModule.UnresolvedSlashedValidatorsCountChanged(
+                    info.nodeOperatorId,
+                    no.unresolvedSlashedValidators
+                );
             }
             touchedOperatorIds[touchedCount] = info.nodeOperatorId;
             trackedBalanceDecreases[touchedCount] = $.keyAllocatedBalance[pointer];

--- a/src/lib/WithdrawnValidatorLib.sol
+++ b/src/lib/WithdrawnValidatorLib.sol
@@ -55,9 +55,17 @@ library WithdrawnValidatorLib {
             if (info.isSlashed != slashed) revert IBaseModule.InvalidWithdrawnValidatorInfo();
             if (info.isSlashed && !$.isValidatorSlashed[pointer]) revert IBaseModule.SlashingPenaltyIsNotApplicable();
 
-            _process($.nodeOperators[info.nodeOperatorId], info, $.keyConfirmedBalance[pointer]);
+            NodeOperator storage no = $.nodeOperators[info.nodeOperatorId];
+            _process(no, info, $.keyConfirmedBalance[pointer]);
 
             $.isValidatorWithdrawn[pointer] = true;
+            // Any withdrawal report accounts for the key losses, hence resolves the slashing.
+            // The decrement is saturating: a slashing reported before the counter was introduced is not counted.
+            if ($.isValidatorSlashed[pointer] && no.unresolvedSlashedValidators != 0) {
+                unchecked {
+                    --no.unresolvedSlashedValidators;
+                }
+            }
             touchedOperatorIds[touchedCount] = info.nodeOperatorId;
             trackedBalanceDecreases[touchedCount] = $.keyAllocatedBalance[pointer];
             unchecked {

--- a/src/lib/WithdrawnValidatorLib.sol
+++ b/src/lib/WithdrawnValidatorLib.sol
@@ -55,20 +55,20 @@ library WithdrawnValidatorLib {
             if (info.isSlashed != slashed) revert IBaseModule.InvalidWithdrawnValidatorInfo();
             if (info.isSlashed && !$.isValidatorSlashed[pointer]) revert IBaseModule.SlashingPenaltyIsNotApplicable();
 
-            NodeOperator storage no = $.nodeOperators[info.nodeOperatorId];
-            _process(no, info, $.keyConfirmedBalance[pointer]);
+            _process($.nodeOperators[info.nodeOperatorId], info, $.keyConfirmedBalance[pointer]);
 
             $.isValidatorWithdrawn[pointer] = true;
             // Any withdrawal report accounts for the key losses, hence resolves the slashing.
-            // The decrement is saturating: a slashing reported before the counter was introduced is not counted.
-            if ($.isValidatorSlashed[pointer] && no.unresolvedSlashedValidators != 0) {
-                unchecked {
-                    --no.unresolvedSlashedValidators;
+            if ($.isValidatorSlashed[pointer]) {
+                uint256 unresolved = $.unresolvedSlashedValidators[info.nodeOperatorId];
+                // The decrement is saturating: a slashing reported before the counter was introduced is not counted.
+                if (unresolved != 0) {
+                    unchecked {
+                        --unresolved;
+                    }
+                    $.unresolvedSlashedValidators[info.nodeOperatorId] = unresolved;
+                    emit IBaseModule.UnresolvedSlashedValidatorsCountChanged(info.nodeOperatorId, unresolved);
                 }
-                emit IBaseModule.UnresolvedSlashedValidatorsCountChanged(
-                    info.nodeOperatorId,
-                    no.unresolvedSlashedValidators
-                );
             }
             touchedOperatorIds[touchedCount] = info.nodeOperatorId;
             trackedBalanceDecreases[touchedCount] = $.keyAllocatedBalance[pointer];

--- a/test/fork/integration/common/Penalty.t.sol
+++ b/test/fork/integration/common/Penalty.t.sol
@@ -3,6 +3,9 @@
 
 pragma solidity 0.8.33;
 
+import { WithdrawnValidatorInfo } from "src/interfaces/IBaseModule.sol";
+import { ValidatorBalanceLimits } from "src/lib/ValidatorBalanceLimits.sol";
+
 import { PermitHelper } from "../../../helpers/Permit.sol";
 import { ModuleTypeBase, CSMIntegrationBase, CSM0x02IntegrationBase, CuratedIntegrationBase } from "./ModuleTypeBase.sol";
 
@@ -34,6 +37,8 @@ abstract contract PenaltyIntegrationTestBase is ModuleTypeBase, PermitHelper {
         module.grantRole(module.DEFAULT_ADMIN_ROLE(), address(this));
         module.grantRole(module.REPORT_GENERAL_DELAYED_PENALTY_ROLE(), address(this));
         module.grantRole(module.SETTLE_GENERAL_DELAYED_PENALTY_ROLE(), address(this));
+        module.grantRole(module.VERIFIER_ROLE(), address(this));
+        module.grantRole(module.REPORT_SLASHED_WITHDRAWN_VALIDATORS_ROLE(), address(this));
         vm.stopPrank();
 
         handleStakingLimit();
@@ -74,6 +79,53 @@ abstract contract PenaltyIntegrationTestBase is ModuleTypeBase, PermitHelper {
         (uint256 bondAfter, ) = accounting.getBondSummaryShares(defaultNoId);
 
         assertEq(bondAfter, bondBefore - amountShares);
+    }
+
+    function test_bondClaimRestrictionAfterSlashing() public assertInvariants {
+        uint256 noId = integrationHelpers.getDepositedNodeOperator(nextAddress(), 1);
+        uint256 keyIndex = _activeNonSlashedKeyIndex(noId);
+        address rewardAddress = module.getNodeOperator(noId).rewardAddress;
+
+        uint256 excessBond = 1 ether;
+        uint256 topUp = accounting.getRequiredBondForNextKeys(noId, 0) + excessBond;
+        vm.deal(user, topUp);
+        vm.prank(user);
+        accounting.depositETH{ value: topUp }(noId);
+        assertGt(accounting.getClaimableBondShares(noId), 0);
+
+        module.reportValidatorSlashing(noId, keyIndex);
+
+        assertTrue(accounting.isBondClaimRestricted(noId));
+        assertEq(accounting.getClaimableBondShares(noId), 0);
+
+        uint256 rewardSharesBefore = lido.sharesOf(rewardAddress);
+        vm.prank(rewardAddress);
+        uint256 claimedShares = accounting.claimRewardsStETH(noId, type(uint256).max, 0, new bytes32[](0));
+        assertEq(claimedShares, 0);
+        assertEq(lido.sharesOf(rewardAddress), rewardSharesBefore);
+
+        WithdrawnValidatorInfo[] memory validatorInfos = new WithdrawnValidatorInfo[](1);
+        validatorInfos[0] = WithdrawnValidatorInfo({
+            nodeOperatorId: noId,
+            keyIndex: keyIndex,
+            exitBalance: ValidatorBalanceLimits.MIN_ACTIVATION_BALANCE,
+            slashingPenalty: excessBond / 10,
+            isSlashed: true
+        });
+        module.reportSlashedWithdrawnValidators(validatorInfos);
+
+        assertFalse(accounting.isBondClaimRestricted(noId));
+        assertGt(accounting.getClaimableBondShares(noId), 0);
+    }
+
+    function _activeNonSlashedKeyIndex(uint256 noId) internal view returns (uint256) {
+        uint256 totalDepositedKeys = module.getNodeOperator(noId).totalDepositedKeys;
+        for (uint256 keyIndex; keyIndex < totalDepositedKeys; ++keyIndex) {
+            if (module.isValidatorWithdrawn(noId, keyIndex)) continue;
+            if (module.isValidatorSlashed(noId, keyIndex)) continue;
+            return keyIndex;
+        }
+        revert("no active non-slashed key");
     }
 }
 

--- a/test/helpers/InvariantAsserts.sol
+++ b/test/helpers/InvariantAsserts.sol
@@ -152,6 +152,31 @@ contract InvariantAsserts is Test {
         );
     }
 
+    /// @dev Only holds for the state built from scratch, since the slashings reported before the counter was
+    ///      introduced are not counted.
+    function assertModuleSlashings(IBaseModule module) public {
+        if (skipInvariants()) return;
+        if (skipLongForkTest()) return;
+
+        uint256 noCount = module.getNodeOperatorsCount();
+
+        for (uint256 noId = 0; noId < noCount; ++noId) {
+            uint256 unresolvedSlashings;
+            uint256 totalDepositedKeys = module.getNodeOperator(noId).totalDepositedKeys;
+
+            for (uint256 keyIndex = 0; keyIndex < totalDepositedKeys; ++keyIndex) {
+                if (module.isValidatorWithdrawn(noId, keyIndex)) continue;
+                if (module.isValidatorSlashed(noId, keyIndex)) ++unresolvedSlashings;
+            }
+
+            assertEq(
+                module.getNodeOperatorUnresolvedSlashedValidators(noId),
+                unresolvedSlashings,
+                "assert unresolved slashings"
+            );
+        }
+    }
+
     mapping(uint256 => uint256) batchKeys;
 
     function assertModuleEnqueuedCount(ICSModule csm) public {

--- a/test/helpers/mocks/CSMMock.sol
+++ b/test/helpers/mocks/CSMMock.sol
@@ -55,6 +55,10 @@ contract CSMMock is Utilities, Fixtures {
         return mockNodeOperator;
     }
 
+    function getNodeOperatorUnresolvedSlashedValidators(uint256 /* nodeOperatorId */) external view returns (uint256) {
+        return mockNodeOperator.unresolvedSlashedValidators;
+    }
+
     function mock_setNodeOperatorManagementProperties(
         NodeOperatorManagementProperties memory _managementProperties
     ) external {

--- a/test/helpers/mocks/CSMMock.sol
+++ b/test/helpers/mocks/CSMMock.sol
@@ -21,6 +21,7 @@ import { LidoLocatorMock } from "./LidoLocatorMock.sol";
 contract CSMMock is Utilities, Fixtures {
     NodeOperator internal mockNodeOperator;
     uint256 internal nodeOperatorsCount;
+    uint256 internal unresolvedSlashedValidators;
     mapping(uint256 => mapping(uint256 => bool)) internal isValidatorWithdrawnByKey;
     IAccounting public immutable ACCOUNTING;
     IParametersRegistry public immutable PARAMETERS_REGISTRY;
@@ -55,8 +56,12 @@ contract CSMMock is Utilities, Fixtures {
         return mockNodeOperator;
     }
 
+    function mock_setNodeOperatorUnresolvedSlashedValidators(uint256 count) external {
+        unresolvedSlashedValidators = count;
+    }
+
     function getNodeOperatorUnresolvedSlashedValidators(uint256 /* nodeOperatorId */) external view returns (uint256) {
-        return mockNodeOperator.unresolvedSlashedValidators;
+        return unresolvedSlashedValidators;
     }
 
     function mock_setNodeOperatorManagementProperties(

--- a/test/unit/Accounting/BondClaimRestriction.t.sol
+++ b/test/unit/Accounting/BondClaimRestriction.t.sol
@@ -22,6 +22,13 @@ contract BondClaimRestrictionTest is BaseTest {
         _deposit({ bond: REQUIRED_BOND + EXCESS_BOND });
     }
 
+    function test_isBondClaimRestricted() public assertInvariants {
+        assertFalse(accounting.isBondClaimRestricted(0));
+
+        mock_getNodeOperatorUnresolvedSlashedValidators(1);
+        assertTrue(accounting.isBondClaimRestricted(0));
+    }
+
     function test_getClaimableBondShares_notRestricted() public assertInvariants {
         assertApproxEqAbs(
             accounting.getClaimableBondShares(0),

--- a/test/unit/Accounting/BondClaimRestriction.t.sol
+++ b/test/unit/Accounting/BondClaimRestriction.t.sol
@@ -1,0 +1,138 @@
+// SPDX-FileCopyrightText: 2026 Lido <info@lido.fi>
+// SPDX-License-Identifier: GPL-3.0
+
+pragma solidity 0.8.33;
+
+import { BaseTest } from "./_Base.t.sol";
+
+// Bond claims are restricted until all the slashed validators are reported as withdrawn and the losses are compensated.
+contract BondClaimRestrictionTest is BaseTest {
+    uint256 internal constant KEYS_COUNT = 16;
+    uint256 internal constant REQUIRED_BOND = 32 ether; // 2 ether per key
+    uint256 internal constant EXCESS_BOND = 8 ether;
+
+    bytes32[] internal proof;
+
+    function setUp() public override {
+        super.setUp();
+
+        proof = new bytes32[](1);
+        mock_getNodeOperatorManagementProperties(user, user, false);
+        _operator({ ongoing: KEYS_COUNT, withdrawn: 0 });
+        _deposit({ bond: REQUIRED_BOND + EXCESS_BOND });
+    }
+
+    function test_getClaimableBondShares_notRestricted() public assertInvariants {
+        assertApproxEqAbs(
+            accounting.getClaimableBondShares(0),
+            stETH.getSharesByPooledEth(EXCESS_BOND),
+            1 wei,
+            "excess bond should be claimable without unresolved slashings"
+        );
+    }
+
+    function test_getClaimableBondShares_zeroWhenRestricted() public assertInvariants {
+        mock_getNodeOperatorUnresolvedSlashedValidators(1);
+
+        assertEq(accounting.getClaimableBondShares(0), 0, "nothing should be claimable while restricted");
+    }
+
+    function test_getClaimableRewardsAndBondShares_zeroWhenRestricted() public assertInvariants {
+        uint256 feeShares = _fundRewards({ fee: 0.1 ether });
+        mock_getNodeOperatorUnresolvedSlashedValidators(1);
+
+        assertEq(
+            accounting.getClaimableRewardsAndBondShares(0, feeShares, proof),
+            0,
+            "neither rewards nor bond should be claimable while restricted"
+        );
+    }
+
+    function test_claimRewardsStETH_claimsNothingButPullsRewardsWhenRestricted() public assertInvariants {
+        uint256 feeShares = _fundRewards({ fee: 0.1 ether });
+        mock_getNodeOperatorUnresolvedSlashedValidators(1);
+
+        uint256 bondSharesBefore = accounting.getBondShares(0);
+
+        vm.prank(user);
+        uint256 claimedShares = accounting.claimRewardsStETH(0, UINT256_MAX, feeShares, proof);
+
+        assertEq(claimedShares, 0, "nothing should be claimed while restricted");
+        assertEq(accounting.getBondShares(0), bondSharesBefore + feeShares, "rewards should be pulled to the bond");
+        assertEq(stETH.sharesOf(user), 0, "nothing should be transferred to the Node Operator");
+    }
+
+    function test_claimRewardsStETH_claimableOnceSlashedValidatorWithdrawalReported() public assertInvariants {
+        mock_getNodeOperatorUnresolvedSlashedValidators(1);
+        assertEq(accounting.getClaimableBondShares(0), 0);
+
+        // The withdrawal report of the slashed validator resolves the slashing.
+        mock_getNodeOperatorUnresolvedSlashedValidators(0);
+
+        vm.prank(user);
+        uint256 claimedShares = accounting.claimRewardsStETH(0, UINT256_MAX, 0, proof);
+
+        assertApproxEqAbs(claimedShares, stETH.getSharesByPooledEth(EXCESS_BOND), 1 wei, "excess bond claimed");
+    }
+
+    function test_claimableStaysZeroUntilLossesCompensated() public assertInvariants {
+        mock_getNodeOperatorUnresolvedSlashedValidators(1);
+
+        // The losses exceed the bond, so the uncovered part becomes the bond debt.
+        uint256 uncoveredLosses = 1 ether;
+        _penalize({ amount: accounting.getBond(0) + uncoveredLosses });
+        assertApproxEqAbs(accounting.getBondDebt(0), uncoveredLosses, 1 wei, "uncovered losses become the bond debt");
+
+        // The withdrawal report lifts the restriction, but the losses are not compensated yet.
+        mock_getNodeOperatorUnresolvedSlashedValidators(0);
+        assertEq(accounting.getClaimableBondShares(0), 0, "nothing to claim until the debt is compensated");
+
+        // A partial compensation is fully spent on the debt.
+        _deposit({ bond: uncoveredLosses / 2 });
+        assertApproxEqAbs(accounting.getBondDebt(0), uncoveredLosses / 2, 2 wei, "debt should be partially covered");
+        assertEq(accounting.getClaimableBondShares(0), 0, "nothing to claim until the debt is compensated");
+
+        _deposit({ bond: uncoveredLosses / 2 + REQUIRED_BOND + EXCESS_BOND });
+        assertEq(accounting.getBondDebt(0), 0, "debt should be fully covered");
+        // Tolerance accounts for the repeated ETH/shares conversions above.
+        assertApproxEqAbs(
+            accounting.getClaimableBondShares(0),
+            stETH.getSharesByPooledEth(EXCESS_BOND),
+            4 wei,
+            "excess bond should be claimable once the losses are compensated"
+        );
+    }
+
+    function test_claimRewardsWstETH_claimsNothingWhenRestricted() public assertInvariants {
+        mock_getNodeOperatorUnresolvedSlashedValidators(1);
+        uint256 bondSharesBefore = accounting.getBondShares(0);
+
+        vm.prank(user);
+        uint256 claimedWstETH = accounting.claimRewardsWstETH(0, UINT256_MAX, 0, proof);
+
+        assertEq(claimedWstETH, 0, "nothing should be claimed while restricted");
+        assertEq(accounting.getBondShares(0), bondSharesBefore, "bond should be intact");
+    }
+
+    function test_claimRewardsUnstETH_claimsNothingWhenRestricted() public assertInvariants {
+        mock_getNodeOperatorUnresolvedSlashedValidators(1);
+        uint256 bondSharesBefore = accounting.getBondShares(0);
+
+        vm.prank(user);
+        uint256 requestId = accounting.claimRewardsUnstETH(0, UINT256_MAX, 0, proof);
+
+        assertEq(requestId, 0, "nothing should be claimed while restricted");
+        assertEq(accounting.getBondShares(0), bondSharesBefore, "bond should be intact");
+    }
+
+    function _fundRewards(uint256 fee) internal returns (uint256 shares) {
+        vm.deal(address(feeDistributor), fee);
+        vm.prank(address(feeDistributor));
+        shares = stETH.submit{ value: fee }(address(0));
+    }
+
+    function _penalize(uint256 amount) internal {
+        vm.prank(address(stakingModule));
+        accounting.penalize(0, amount);
+    }
+}

--- a/test/unit/Accounting/_Base.t.sol
+++ b/test/unit/Accounting/_Base.t.sol
@@ -76,6 +76,14 @@ contract AccountingFixtures is Test, Fixtures, Utilities, InvariantAsserts {
         );
     }
 
+    function mock_getNodeOperatorUnresolvedSlashedValidators(uint256 returnValue) internal {
+        vm.mockCall(
+            address(stakingModule),
+            abi.encodeWithSelector(IBaseModule.getNodeOperatorUnresolvedSlashedValidators.selector, 0),
+            abi.encode(returnValue)
+        );
+    }
+
     function mock_updateDepositableValidatorsCount() internal {
         vm.mockCall(
             address(stakingModule),
@@ -145,6 +153,7 @@ contract BaseTest is AccountingFixtures {
         mock_updateDepositableValidatorsCount();
         mock_updateDepositInfo(0);
         mock_requestFullDepositInfoUpdate();
+        mock_getNodeOperatorUnresolvedSlashedValidators(0);
 
         IBondCurve.BondCurveIntervalInput[] memory curve = new IBondCurve.BondCurveIntervalInput[](1);
         curve[0] = IBondCurve.BondCurveIntervalInput({ minKeysCount: 1, trend: 2 ether });

--- a/test/unit/CSModule.t.sol
+++ b/test/unit/CSModule.t.sol
@@ -110,6 +110,7 @@ contract CSMCommon is ModuleFixtures {
     function _moduleInvariants() internal override {
         assertModuleEnqueuedCount(csm);
         assertModuleKeys(module);
+        assertModuleSlashings(module);
     }
 
     // Checks that the queue is in the expected state starting from its head.

--- a/test/unit/CuratedModule.t.sol
+++ b/test/unit/CuratedModule.t.sol
@@ -171,6 +171,7 @@ contract CuratedCommon is ModuleFixtures {
 
     function _moduleInvariants() internal override {
         assertModuleKeys(module);
+        assertModuleSlashings(module);
     }
 
     function _topUpToOperatorBalance(uint256 nodeOperatorId, uint256 keyIndex, uint256 targetBalanceWei) internal {

--- a/test/unit/ModuleAbstract/PenaltiesWithdrawn.t.sol
+++ b/test/unit/ModuleAbstract/PenaltiesWithdrawn.t.sol
@@ -7,10 +7,14 @@ import { ExitPenaltyInfo, MarkedUint248 } from "src/interfaces/IExitPenalties.so
 import { IBaseModule, NodeOperator, WithdrawnValidatorInfo } from "src/interfaces/IBaseModule.sol";
 import { WithdrawnValidatorLib } from "src/lib/WithdrawnValidatorLib.sol";
 import { ValidatorBalanceLimits } from "src/lib/ValidatorBalanceLimits.sol";
+import { KeyPointerLib } from "src/lib/KeyPointerLib.sol";
 
 import { ModuleFixtures } from "./_Base.t.sol";
 
 abstract contract ModuleReportWithdrawnValidators is ModuleFixtures {
+    /// @dev `BaseModuleStorage.isValidatorSlashed` mapping slot
+    uint256 internal constant IS_VALIDATOR_SLASHED_SLOT = 8;
+
     function test_isValidatorWithdrawn_DefaultFalse() public assertInvariants {
         uint256 noId = createNodeOperator(1);
 
@@ -1307,6 +1311,37 @@ abstract contract ModuleReportWithdrawnValidators is ModuleFixtures {
         module.isValidatorSlashed(noId, 1);
     }
 
+    function test_reportValidatorSlashing_unresolvedSlashedValidatorsCounter() public assertInvariants {
+        uint256 keysCount = 2;
+        uint256 noId = createNodeOperator(keysCount);
+        module.obtainDepositData(keysCount, "");
+
+        assertEq(module.getNodeOperatorUnresolvedSlashedValidators(noId), 0);
+
+        module.reportValidatorSlashing(noId, 0);
+        module.reportValidatorSlashing(noId, 1);
+        assertEq(module.getNodeOperatorUnresolvedSlashedValidators(noId), keysCount);
+
+        WithdrawnValidatorInfo[] memory validatorInfos = new WithdrawnValidatorInfo[](1);
+        validatorInfos[0] = WithdrawnValidatorInfo({
+            nodeOperatorId: noId,
+            keyIndex: 0,
+            exitBalance: ValidatorBalanceLimits.MIN_ACTIVATION_BALANCE,
+            slashingPenalty: 1 ether,
+            isSlashed: true
+        });
+        module.reportSlashedWithdrawnValidators(validatorInfos);
+        assertEq(
+            module.getNodeOperatorUnresolvedSlashedValidators(noId),
+            keysCount - 1,
+            "slashing should be resolved by the withdrawal report"
+        );
+
+        validatorInfos[0].keyIndex = 1;
+        module.reportSlashedWithdrawnValidators(validatorInfos);
+        assertEq(module.getNodeOperatorUnresolvedSlashedValidators(noId), 0);
+    }
+
     function test_reportValidatorSlashing_RevertWhen_CalledTwice() public {
         uint256 noId = createNodeOperator(17);
         module.obtainDepositData(17, "");
@@ -1315,6 +1350,82 @@ abstract contract ModuleReportWithdrawnValidators is ModuleFixtures {
         module.reportValidatorSlashing(noId, keyIndex);
         vm.expectRevert(IBaseModule.ValidatorSlashingAlreadyReported.selector, address(module));
         module.reportValidatorSlashing(noId, keyIndex);
+    }
+
+    function test_reportRegularWithdrawnValidators_resolvesSlashingOfSlashedKey() public assertInvariants {
+        uint256 noId = createNodeOperator();
+        module.obtainDepositData(1, "");
+        module.reportValidatorSlashing(noId, 0);
+        assertEq(module.getNodeOperatorUnresolvedSlashedValidators(noId), 1);
+
+        // A slashed key might be reported as a regular withdrawal, i.e. penalized by the exit balance shortage.
+        uint256 balanceShortage = 1 ether;
+        WithdrawnValidatorInfo[] memory validatorInfos = new WithdrawnValidatorInfo[](1);
+        validatorInfos[0] = WithdrawnValidatorInfo({
+            nodeOperatorId: noId,
+            keyIndex: 0,
+            exitBalance: ValidatorBalanceLimits.MIN_ACTIVATION_BALANCE - balanceShortage,
+            slashingPenalty: 0,
+            isSlashed: false
+        });
+
+        vm.expectCall(address(accounting), abi.encodeWithSelector(accounting.penalize.selector, noId, balanceShortage));
+        module.reportRegularWithdrawnValidators(validatorInfos);
+
+        assertEq(
+            module.getNodeOperatorUnresolvedSlashedValidators(noId),
+            0,
+            "the losses are accounted for, so the slashing should be resolved"
+        );
+    }
+
+    function test_reportSlashedWithdrawnValidators_slashingReportedBeforeUpgrade() public assertInvariants {
+        uint256 noId = createNodeOperator();
+        module.obtainDepositData(1, "");
+
+        // A validator slashed before the upgrade has no unresolved slashing counted.
+        uint256 pointer = KeyPointerLib.keyPointer(noId, 0);
+        vm.store(address(module), keccak256(abi.encode(pointer, IS_VALIDATOR_SLASHED_SLOT)), bytes32(uint256(1)));
+        assertTrue(module.isValidatorSlashed(noId, 0));
+        assertEq(module.getNodeOperatorUnresolvedSlashedValidators(noId), 0);
+
+        WithdrawnValidatorInfo[] memory validatorInfos = new WithdrawnValidatorInfo[](1);
+        validatorInfos[0] = WithdrawnValidatorInfo({
+            nodeOperatorId: noId,
+            keyIndex: 0,
+            exitBalance: ValidatorBalanceLimits.MIN_ACTIVATION_BALANCE,
+            slashingPenalty: 1 ether,
+            isSlashed: true
+        });
+
+        module.reportSlashedWithdrawnValidators(validatorInfos);
+
+        assertTrue(module.isValidatorWithdrawn(noId, 0));
+        assertEq(module.getNodeOperatorUnresolvedSlashedValidators(noId), 0);
+    }
+
+    function test_reportValidatorSlashing_retrospectiveReportKeepsSlashingResolved() public assertInvariants {
+        uint256 noId = createNodeOperator();
+        module.obtainDepositData(1, "");
+
+        WithdrawnValidatorInfo[] memory validatorInfos = new WithdrawnValidatorInfo[](1);
+        validatorInfos[0] = WithdrawnValidatorInfo({
+            nodeOperatorId: noId,
+            keyIndex: 0,
+            exitBalance: ValidatorBalanceLimits.MIN_ACTIVATION_BALANCE,
+            slashingPenalty: 0,
+            isSlashed: false
+        });
+        module.reportRegularWithdrawnValidators(validatorInfos);
+
+        module.reportValidatorSlashing(noId, 0);
+
+        assertTrue(module.isValidatorSlashed(noId, 0));
+        assertEq(
+            module.getNodeOperatorUnresolvedSlashedValidators(noId),
+            0,
+            "a slashing of a withdrawn validator has nothing left to resolve"
+        );
     }
 
     function test_reportValidatorSlashing_RevertWhen_OperatorDoesNotExist() public {

--- a/test/unit/ModuleAbstract/PenaltiesWithdrawn.t.sol
+++ b/test/unit/ModuleAbstract/PenaltiesWithdrawn.t.sol
@@ -1318,7 +1318,12 @@ abstract contract ModuleReportWithdrawnValidators is ModuleFixtures {
 
         assertEq(module.getNodeOperatorUnresolvedSlashedValidators(noId), 0);
 
+        vm.expectEmit(address(module));
+        emit IBaseModule.UnresolvedSlashedValidatorsCountChanged(noId, 1);
         module.reportValidatorSlashing(noId, 0);
+
+        vm.expectEmit(address(module));
+        emit IBaseModule.UnresolvedSlashedValidatorsCountChanged(noId, 2);
         module.reportValidatorSlashing(noId, 1);
         assertEq(module.getNodeOperatorUnresolvedSlashedValidators(noId), keysCount);
 
@@ -1330,6 +1335,9 @@ abstract contract ModuleReportWithdrawnValidators is ModuleFixtures {
             slashingPenalty: 1 ether,
             isSlashed: true
         });
+
+        vm.expectEmit(address(module));
+        emit IBaseModule.UnresolvedSlashedValidatorsCountChanged(noId, 1);
         module.reportSlashedWithdrawnValidators(validatorInfos);
         assertEq(
             module.getNodeOperatorUnresolvedSlashedValidators(noId),


### PR DESCRIPTION
## Description

Temporary bond claim restriction after slashing.

- Slashing report increments `NodeOperator.unresolvedSlashedValidators`; while it is non-zero, claimable bond is 0, so bond claims and fee split payouts are blocked.
- Withdrawal report of the slashed key decrements the counter and lifts the restriction, covering both slashing penalty modes.
- Losses uncovered by the bond become `bondDebt`, so nothing is claimable until they are compensated.

## Checklist

- [x] Appropriate PR labels applied
- [x] Test coverage maintained (`just coverage`)
  - [ ] No need to add/update tests
  - [x] Tests are added/updated
- [x] Documentation maintained
  - [x] No need to update
  - [ ] Updated
