### PR TITLE
fix: batch Circles Trust logs, make Gnosis RPC and IPFS gateway confi…

### DIFF
--- a/ics_assessment/.env.sample
+++ b/ics_assessment/.env.sample
@@ -1,10 +1,10 @@
 MAINNET_RPC_URL=
 HOODI_RPC_URL=
 ARBITRUM_RPC_URL=
-# Optional. Defaults to https://rpc.gnosis.gateway.fm, whose backends
-# fail intermittently; point it at a dedicated provider for `sync circles`.
+# Optional (unset or empty uses the default https://rpc.gnosis.gateway.fm).
+# A dedicated archival provider is recommended for reproducible Circles reads.
 GNOSIS_RPC_URL=
-# Optional. Remove if you already have archive URLs above.
+# Optional. Unset or empty falls back to the corresponding common RPC.
 MAINNET_ARCHIVE_RPC_URL=
 HOODI_ARCHIVE_RPC_URL=
 
@@ -14,3 +14,6 @@ HUMAN_PASSPORT_API_KEY=
 # Optional. IPFS gateway for performance reports.
 # Defaults to https://gateway.pinata.cloud/ipfs
 IPFS_GATEWAY_URL=
+
+# Optional block span per log request (default: 10000).
+ICS_SYNC_CHUNK_SIZE=

--- a/ics_assessment/.env.sample
+++ b/ics_assessment/.env.sample
@@ -1,9 +1,16 @@
 MAINNET_RPC_URL=
 HOODI_RPC_URL=
 ARBITRUM_RPC_URL=
+# Optional. Defaults to https://rpc.gnosis.gateway.fm, whose backends
+# fail intermittently; point it at a dedicated provider for `sync circles`.
+GNOSIS_RPC_URL=
 # Optional. Remove if you already have archive URLs above.
 MAINNET_ARCHIVE_RPC_URL=
 HOODI_ARCHIVE_RPC_URL=
 
 HIGH_SIGNAL_API_KEY=
 HUMAN_PASSPORT_API_KEY=
+
+# Optional. IPFS gateway for performance reports.
+# Defaults to https://gateway.pinata.cloud/ipfs
+IPFS_GATEWAY_URL=

--- a/ics_assessment/README.md
+++ b/ics_assessment/README.md
@@ -120,6 +120,7 @@ python main.py sync snapshot galxe gitpoap
 # Sync with a custom chunk size
 python main.py sync --chunk-size 50000 aragon
 python main.py sync --chunk-size 50000 mainnet-performance
+python main.py sync --chunk-size 10000 circles
 ```
 
 Supported sync targets:
@@ -194,6 +195,12 @@ Important sync outputs:
 
 The assessment now reads compact eligible-node artifacts for both mainnet and Hoodi CSM checks. Raw mainnet performance report JSON files are not needed at runtime.
 
+`node-owners` records the manager and reward addresses for each operator at the
+chain cutoff. Either address can identify an eligible operator, regardless of extended
+manager permissions; activity and performance requirements are unchanged.
+Recognizing experience through either address does not change claim permissions:
+claiming ICS for an existing operator still requires its on-chain owner.
+
 Mainnet performance sync reads the complete report history from
 `DistributionLogUpdated` events, starting with the first CSM v1 report and
 ending at `MAINNET_CUTOFF_BLOCK`. Mainnet eligibility requires at least 30
@@ -256,15 +263,19 @@ Environment variables used by sync:
   - `MAINNET_RPC_URL`
   - `HOODI_RPC_URL`
   - `ARBITRUM_RPC_URL`
+  - `GNOSIS_RPC_URL` (defaults to `https://rpc.gnosis.gateway.fm`)
 - archive RPCs for historical node-owner state:
   - `MAINNET_ARCHIVE_RPC_URL`
   - `HOODI_ARCHIVE_RPC_URL`
-  - if unset, they fall back to `MAINNET_RPC_URL` and `HOODI_RPC_URL`
+  - if unset or empty, they fall back to `MAINNET_RPC_URL` and `HOODI_RPC_URL`
 
 Operational note:
 
 - Infura has worked better for the common RPCs because it is less restrictive on large event/log fetch ranges.
 - Alchemy has worked better for archive RPCs used by historical node-owner state reads.
+- `IPFS_GATEWAY_URL` configures both performance-report downloaders and defaults
+  to `https://gateway.pinata.cloud/ipfs`. Empty optional endpoint variables use
+  their defaults.
 - If sync exits before starting a target, export the required RPC env vars above and retry.
 
 ## Data Layout
@@ -318,12 +329,12 @@ Live at runtime:
 - `MAINNET_ARCHIVE_RPC_URL`
 - `HOODI_ARCHIVE_RPC_URL`
 - `ICS_SYNC_CHUNK_SIZE`
-  - optional default chunk size for sync log fetching
+  - optional block span for sync log fetching (default: 10,000 blocks)
 
 ## Tests
 
 ```bash
-pytest ics_assessment/tests
+PYTHON_DOTENV_DISABLED=1 python -m pytest ics_assessment/tests
 ```
 
 The suite includes:

--- a/ics_assessment/config.py
+++ b/ics_assessment/config.py
@@ -24,11 +24,11 @@ REQUIRED_ACTIVITY_WINDOW_MAINNET = 30
 MAINNET_RPC_URL = os.getenv("MAINNET_RPC_URL")
 HOODI_RPC_URL = os.getenv("HOODI_RPC_URL")
 ARBITRUM_RPC_URL = os.getenv("ARBITRUM_RPC_URL")
-MAINNET_ARCHIVE_RPC_URL = os.getenv("MAINNET_ARCHIVE_RPC_URL", MAINNET_RPC_URL or "")
-HOODI_ARCHIVE_RPC_URL = os.getenv("HOODI_ARCHIVE_RPC_URL", HOODI_RPC_URL or "")
-GNOSIS_RPC_URL = os.getenv("GNOSIS_RPC_URL", "https://rpc.gnosis.gateway.fm")
-IPFS_GATEWAY_URL = os.getenv(
-    "IPFS_GATEWAY_URL", "https://gateway.pinata.cloud/ipfs"
+MAINNET_ARCHIVE_RPC_URL = os.getenv("MAINNET_ARCHIVE_RPC_URL") or MAINNET_RPC_URL or ""
+HOODI_ARCHIVE_RPC_URL = os.getenv("HOODI_ARCHIVE_RPC_URL") or HOODI_RPC_URL or ""
+GNOSIS_RPC_URL = os.getenv("GNOSIS_RPC_URL") or "https://rpc.gnosis.gateway.fm"
+IPFS_GATEWAY_URL = (
+    os.getenv("IPFS_GATEWAY_URL") or "https://gateway.pinata.cloud/ipfs"
 ).rstrip("/")
 
 

--- a/ics_assessment/config.py
+++ b/ics_assessment/config.py
@@ -26,7 +26,10 @@ HOODI_RPC_URL = os.getenv("HOODI_RPC_URL")
 ARBITRUM_RPC_URL = os.getenv("ARBITRUM_RPC_URL")
 MAINNET_ARCHIVE_RPC_URL = os.getenv("MAINNET_ARCHIVE_RPC_URL", MAINNET_RPC_URL or "")
 HOODI_ARCHIVE_RPC_URL = os.getenv("HOODI_ARCHIVE_RPC_URL", HOODI_RPC_URL or "")
-GNOSIS_RPC_URL = "https://rpc.gnosis.gateway.fm"
+GNOSIS_RPC_URL = os.getenv("GNOSIS_RPC_URL", "https://rpc.gnosis.gateway.fm")
+IPFS_GATEWAY_URL = os.getenv(
+    "IPFS_GATEWAY_URL", "https://gateway.pinata.cloud/ipfs"
+).rstrip("/")
 
 
 # Category scoring policy.

--- a/ics_assessment/experience/sources.py
+++ b/ics_assessment/experience/sources.py
@@ -2,7 +2,7 @@ import json
 from dataclasses import dataclass
 from pathlib import Path
 
-from ics_assessment.data_utils import read_csv_rows
+from ics_assessment.data_utils import normalize_evm_addresses, read_csv_rows
 
 
 @dataclass(frozen=True)
@@ -27,18 +27,27 @@ def csv_matches(addresses: set[str], csv_file: str, base_dir: Path) -> list[str]
 
 def matched_node_operator_ids(addresses: set[str], owners_path: Path) -> list[str]:
     node_operators = load_owner_map(owners_path)
+    addresses = normalize_evm_addresses(addresses)
     return sorted(
         {
             no_id
-            for no_id, address in node_operators.items()
-            if address.lower() in addresses
+            for no_id, operator_addresses in node_operators.items()
+            if operator_addresses & addresses
         }
     )
 
 
-def load_owner_map(owners_path: Path) -> dict[str, str]:
+def load_owner_map(owners_path: Path) -> dict[str, set[str]]:
     with owners_path.open("r", encoding="utf-8") as file:
-        return json.load(file)
+        operators = json.load(file)
+    result = {}
+    for operator_id, addresses in operators.items():
+        if not isinstance(addresses, list):
+            raise ValueError(
+                "Run 'python main.py sync node-owners' to regenerate manager and reward addresses."
+            )
+        result[operator_id] = normalize_evm_addresses(addresses)
+    return result
 
 
 def load_hoodi_eligible_ids(sources: ExperienceSources) -> set[str]:
@@ -51,11 +60,11 @@ def load_mainnet_eligible_ids(sources: ExperienceSources) -> set[str]:
         return set(json.load(file))
 
 
-def load_hoodi_owner_map(sources: ExperienceSources) -> dict[str, str]:
+def load_hoodi_owner_map(sources: ExperienceSources) -> dict[str, set[str]]:
     return load_owner_map(sources.node_operator_owners_hoodi_path)
 
 
-def load_mainnet_owner_map(sources: ExperienceSources) -> dict[str, str]:
+def load_mainnet_owner_map(sources: ExperienceSources) -> dict[str, set[str]]:
     return load_owner_map(sources.node_operator_owners_mainnet_path)
 
 

--- a/ics_assessment/experience/sync.py
+++ b/ics_assessment/experience/sync.py
@@ -91,7 +91,7 @@ async def _sync_node_operator_owners_one(
             decode_tuples=True,
         )
 
-        node_operators: dict[int, str] = {}
+        node_operators: dict[int, set[str]] = {}
         count = await contract.functions.getNodeOperatorsCount().call(
             block_identifier=reference_block
         )
@@ -117,12 +117,11 @@ async def _sync_node_operator_owners_one(
                 node_operator = await contract.functions.getNodeOperator(i).call(
                     block_identifier=reference_block
                 )
-                owner = (
-                    node_operator.managerAddress
-                    if node_operator.extendedManagerPermissions
-                    else node_operator.rewardAddress
-                )
-                node_operators[i] = owner.lower()
+                # Either management role can identify an applicant's operator.
+                node_operators[i] = {
+                    node_operator.managerAddress.lower(),
+                    node_operator.rewardAddress.lower(),
+                }
                 async with progress_lock:
                     processed += 1
                     if processed % 100 == 0 or processed == count:
@@ -163,7 +162,8 @@ async def _sync_node_operator_owners_one(
             ) as file:
                 temp_path = Path(file.name)
                 json.dump(
-                    dict(sorted(node_operators.items(), key=lambda item: item[0])),
+                    {operator_id: sorted(addresses)
+                     for operator_id, addresses in sorted(node_operators.items())},
                     file,
                     indent=2,
                 )

--- a/ics_assessment/experience/sync.py
+++ b/ics_assessment/experience/sync.py
@@ -17,6 +17,7 @@ from ics_assessment.config import (
     HOODI_FEE_DISTRIBUTOR_ADDRESS,
     HOODI_FEE_DISTRIBUTOR_FROM_BLOCK,
     HOODI_RPC_URL,
+    IPFS_GATEWAY_URL,
     MAINNET_ARCHIVE_RPC_URL,
     MAINNET_CUTOFF_BLOCK,
     MAINNET_FEE_DISTRIBUTOR_ADDRESS,
@@ -216,7 +217,7 @@ def _fetch_cids_via_getlogs(w3: Web3, address: str, from_block: int, to_block: i
 
 
 def request_performance_report(cid: str) -> dict | list[dict]:
-    url = f"https://ipfs.io/ipfs/{cid}"
+    url = f"{IPFS_GATEWAY_URL}/{cid}"
     last_exc: Exception | None = None
     for _ in range(3):
         try:

--- a/ics_assessment/experience/sync_hoodi.py
+++ b/ics_assessment/experience/sync_hoodi.py
@@ -15,6 +15,7 @@ from ics_assessment.config import (
     HOODI_FEE_DISTRIBUTOR_ADDRESS,
     HOODI_FEE_DISTRIBUTOR_FROM_BLOCK,
     HOODI_RPC_URL,
+    IPFS_GATEWAY_URL,
     REQUIRED_PERFORMANCE_WINDOW_HOODI,
 )
 from ics_assessment.sync import get_raw_logs
@@ -61,7 +62,7 @@ EPOCH_SECONDS = SLOTS_PER_EPOCH * SECONDS_PER_SLOT  # 384s
 
 
 def request_performance_report(cid: str, retries: int = 3, delay: float = 1.5) -> dict:
-    url = f"https://ipfs.io/ipfs/{cid}"
+    url = f"{IPFS_GATEWAY_URL}/{cid}"
     last_exc: Optional[Exception] = None
     for _ in range(retries):
         try:

--- a/ics_assessment/humanity/sync.py
+++ b/ics_assessment/humanity/sync.py
@@ -9,7 +9,13 @@ from ics_assessment.config import (
     GROUP_ADDRESS,
     GROUP_CREATION_BLOCK,
 )
-from ics_assessment.sync import GROUP_ABI, HUB_ABI, SAFE_ABI, write_lines
+from ics_assessment.sync import (
+    GROUP_ABI,
+    HUB_ABI,
+    SAFE_ABI,
+    get_event_logs,
+    write_lines,
+)
 
 
 def sync_circles() -> None:
@@ -22,11 +28,13 @@ def sync_circles() -> None:
         block_identifier=GNOSIS_CUTOFF_BLOCK
     )
     hub_contract = w3.eth.contract(address=w3.to_checksum_address(hub_address), abi=HUB_ABI)
-    events = hub_contract.events.Trust.create_filter(
-        from_block=GROUP_CREATION_BLOCK,
-        to_block=GNOSIS_CUTOFF_BLOCK,
+    events = get_event_logs(
+        hub_contract.events.Trust(),
+        GROUP_CREATION_BLOCK,
+        GNOSIS_CUTOFF_BLOCK,
+        label="Circles Trust",
         argument_filters={"truster": w3.to_checksum_address(GROUP_ADDRESS)},
-    ).get_all_entries()
+    )
     trustees = {
         event.args.trustee
         for event in events

--- a/ics_assessment/sync.py
+++ b/ics_assessment/sync.py
@@ -18,6 +18,9 @@ from ics_assessment.config import (
 )
 
 
+DEFAULT_LOG_CHUNK_SIZE = 10_000
+
+
 TRANSFER_EVENT_ABI = [
     {
         "type": "event",
@@ -116,7 +119,9 @@ def _fetch_logs(
                     )
             raise
 
-    if chunk_size is None or (to_block - from_block + 1) <= chunk_size:
+    if chunk_size is None:
+        chunk_size = DEFAULT_LOG_CHUNK_SIZE
+    if (to_block - from_block + 1) <= chunk_size:
         print(f"[sync] {label}: fetching {_format_block_range(from_block, to_block)}")
         logs = run_fetch(from_block, to_block)
         print(f"[sync] {label}: fetched {len(logs)} log(s) for {_format_block_range(from_block, to_block)}")
@@ -314,7 +319,7 @@ def run_sync(targets: list[str], chunk_size: int | None = None) -> int:
 
 def main(argv: list[str] | None = None, *, chunk_size: int | None = None) -> int:
     parser = argparse.ArgumentParser(description="Sync ICS assessment snapshot sources.")
-    parser.add_argument("--chunk-size", type=int, default=chunk_size, help="Optional log-fetch block chunk size")
+    parser.add_argument("--chunk-size", type=int, default=chunk_size, help="Log-fetch block chunk size (default: 10000)")
     parser.add_argument("targets", nargs="*", help="Sync target(s) or 'all'")
     args = parser.parse_args(argv)
     return run_sync(args.targets, chunk_size=args.chunk_size)

--- a/ics_assessment/sync.py
+++ b/ics_assessment/sync.py
@@ -143,9 +143,16 @@ def _fetch_logs(
     return logs
 
 
-def get_event_logs(event, from_block: int, to_block: int, label: str = "event logs"):
+def get_event_logs(
+    event,
+    from_block: int,
+    to_block: int,
+    label: str = "event logs",
+    argument_filters: dict | None = None,
+):
+    extra = {"argument_filters": argument_filters} if argument_filters else {}
     return _fetch_logs(
-        lambda start, end: event.get_logs(from_block=start, to_block=end),
+        lambda start, end: event.get_logs(from_block=start, to_block=end, **extra),
         from_block,
         to_block,
         label,

--- a/ics_assessment/tests/test_experience_main.py
+++ b/ics_assessment/tests/test_experience_main.py
@@ -34,6 +34,8 @@ def mod(tmp_path):
 
 def _write_json(path: Path, value) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
+    if path.name.startswith("node_operator_owners_"):
+        value = {operator_id: [addr] for operator_id, addr in value.items()}
     path.write_text(json.dumps(value))
 
 

--- a/ics_assessment/tests/test_log_ranges.py
+++ b/ics_assessment/tests/test_log_ranges.py
@@ -1,0 +1,30 @@
+import pytest
+
+from ics_assessment.sync import _fetch_logs as fetch_logs
+
+
+def entry(block, index=0):
+    return {
+        "blockNumber": block,
+        "logIndex": index,
+        "blockHash": block.to_bytes(32, "big"),
+        "transactionHash": (block + 1).to_bytes(32, "big"),
+    }
+
+
+@pytest.mark.parametrize("start,end", [(0, 0), (0, 9), (7, 21), (10, 19)])
+@pytest.mark.parametrize("size", [1, 2, 5, 10, 11])
+def test_inclusive_range_partition_has_no_gaps_or_duplicate_boundaries(
+    start, end, size
+):
+    ranges = []
+
+    def fetch(first, last):
+        ranges.append((first, last))
+        return [entry(block) for block in range(first, last + 1)]
+
+    assert [
+        log["blockNumber"] for log in fetch_logs(fetch, start, end, "test", size)
+    ] == list(range(start, end + 1))
+    assert ranges[0][0] == start and ranges[-1][1] == end
+    assert all(last - first + 1 <= size for first, last in ranges)

--- a/ics_assessment/tests/test_manager_addresses.py
+++ b/ics_assessment/tests/test_manager_addresses.py
@@ -1,0 +1,143 @@
+import asyncio
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from ics_assessment import sync
+from ics_assessment.experience.assess import ExperienceEvaluator
+from ics_assessment.experience.sources import ExperienceSources, load_owner_map
+
+MANAGER = "0x368Da1891a15cc84bb91E672710bEA0B46CaC393"
+REWARD = "0x81932353c285e5f47F7366fcdcaCbD1D49a0B02b"
+STRANGER = "0x" + "ab" * 20
+
+
+@pytest.fixture
+def sources(tmp_path):
+    result = ExperienceSources(
+        data_dir=tmp_path,
+        static_dir=tmp_path,
+        circles_group_members_path=tmp_path / "circles.csv",
+        eligible_addresses_holesky_path=tmp_path / "holesky.json",
+        eligible_node_operators_hoodi_path=tmp_path / "hoodi-eligible.json",
+        eligible_node_operators_mainnet_path=tmp_path / "mainnet-eligible.json",
+        node_operator_owners_hoodi_path=tmp_path / "hoodi-owners.json",
+        node_operator_owners_mainnet_path=tmp_path / "mainnet-owners.json",
+    )
+    result.eligible_addresses_holesky_path.write_text("[]")
+    result.circles_group_members_path.write_text("")
+    for chain in ("mainnet", "hoodi"):
+        getattr(result, f"eligible_node_operators_{chain}_path").write_text('["583"]')
+        getattr(result, f"node_operator_owners_{chain}_path").write_text(
+            json.dumps(
+                {
+                    "583": [MANAGER, REWARD],
+                }
+            )
+        )
+    return result
+
+
+@pytest.mark.parametrize("chain,points", [("mainnet", 6), ("hoodi", 4)])
+@pytest.mark.parametrize("addresses", [{MANAGER}, {REWARD}, {MANAGER, REWARD}])
+def test_both_management_roles_recognize_eligible_operator_once(
+    sources, chain, points, addresses
+):
+    evaluator = ExperienceEvaluator(sources)
+    assert (
+        getattr(
+            evaluator, f"_csm_{'testnet' if chain == 'hoodi' else 'mainnet'}_score"
+        )(addresses)
+        == points
+    )
+
+
+@pytest.mark.parametrize("chain", ["mainnet", "hoodi"])
+def test_an_unrelated_address_does_not_inherit_operator_experience(sources, chain):
+    evaluator = ExperienceEvaluator(sources)
+    assert (
+        getattr(
+            evaluator, f"_csm_{'testnet' if chain == 'hoodi' else 'mainnet'}_score"
+        )({STRANGER})
+        == 0
+    )
+
+
+@pytest.mark.parametrize("chain", ["mainnet", "hoodi"])
+def test_management_address_still_needs_operator_performance(sources, chain):
+    getattr(sources, f"eligible_node_operators_{chain}_path").write_text("[]")
+    evaluator = ExperienceEvaluator(sources)
+    assert (
+        getattr(
+            evaluator, f"_csm_{'testnet' if chain == 'hoodi' else 'mainnet'}_score"
+        )({MANAGER, REWARD})
+        == 0
+    )
+
+
+def test_all_operator_ids_are_checked_for_a_shared_manager(sources):
+    owners = {
+        str(operator): [MANAGER, REWARD]
+        for operator in (582, 583)
+    }
+    sources.node_operator_owners_mainnet_path.write_text(json.dumps(owners))
+    assert ExperienceEvaluator(sources)._csm_mainnet_score({MANAGER}) == 6
+
+
+@pytest.mark.parametrize("extended", [False, True])
+@pytest.mark.parametrize("reward", [REWARD, MANAGER])
+def test_sync_keeps_unique_addresses_regardless_of_extended_permissions(
+    monkeypatch, tmp_path, extended, reward
+):
+    calls = []
+
+    async def count_call(block_identifier):
+        calls.append(block_identifier)
+        return 1
+
+    async def operator_call(block_identifier):
+        calls.append(block_identifier)
+        return SimpleNamespace(
+            managerAddress=MANAGER,
+            rewardAddress=reward,
+            extendedManagerPermissions=extended,
+        )
+
+    async def disconnect():
+        calls.append("disconnected")
+
+    contract = SimpleNamespace(
+        functions=SimpleNamespace(
+            getNodeOperatorsCount=lambda: SimpleNamespace(call=count_call),
+            getNodeOperator=lambda operator: SimpleNamespace(call=operator_call),
+        )
+    )
+
+    class FakeAsyncWeb3:
+        AsyncHTTPProvider = staticmethod(lambda url: url)
+
+        def __init__(self, provider):
+            self.eth = SimpleNamespace(contract=lambda **kwargs: contract)
+            self.provider = SimpleNamespace(disconnect=disconnect)
+
+    monkeypatch.setattr(sync.experience_jobs, "AsyncWeb3", FakeAsyncWeb3)
+    path = tmp_path / "owners.json"
+    asyncio.run(
+        sync.experience_jobs._sync_node_operator_owners_one(
+            "https://rpc.example", "contract", 25928919, path
+        )
+    )
+    assert json.loads(path.read_text()) == {
+        "0": sorted({MANAGER.lower(), reward.lower()})
+    }
+    assert load_owner_map(path) == {"0": {MANAGER.lower(), reward.lower()}}
+    assert calls == [25928919, 25928919, "disconnected"]
+
+
+@pytest.mark.parametrize("old_value", [REWARD, {"managerAddress": MANAGER, "rewardAddress": REWARD}])
+def test_old_owner_maps_require_resync(tmp_path, old_value):
+    path = tmp_path / "owners.json"
+    path.write_text(json.dumps({"583": old_value}))
+    with pytest.raises(ValueError, match="sync node-owners"):
+        load_owner_map(path)

--- a/ics_assessment/tests/test_static_prepared_data.py
+++ b/ics_assessment/tests/test_static_prepared_data.py
@@ -1,5 +1,8 @@
 import csv
 import json
+from dataclasses import replace
+
+import pytest
 from pathlib import Path
 
 from ics_assessment.config import (
@@ -52,6 +55,22 @@ HUMANITY_SOURCES = HumanitySources(
     ssv_verified_operators_path=SSV_VERIFIED_OPERATORS_PATH,
 )
 HUMANITY_EVALUATOR = HumanityEvaluator(HUMANITY_SOURCES)
+
+
+@pytest.fixture(autouse=True)
+def management_address_fixtures(monkeypatch, tmp_path):
+    # Retained round artifacts use the old owner-only schema. Adapt known owners
+    # in fixtures only; real sync must fetch both roles from the contract.
+    replacements = {}
+    for chain in ("mainnet", "hoodi"):
+        field = f"node_operator_owners_{chain}_path"
+        old = getattr(EXPERIENCE_SOURCES, field)
+        owners = json.loads(old.read_text())
+        new = tmp_path / old.name
+        new.write_text(json.dumps({key: ([value] if isinstance(value, str) else value)
+                                   for key, value in owners.items()}))
+        replacements[field] = new
+    monkeypatch.setattr(EXPERIENCE_EVALUATOR, "sources", replace(EXPERIENCE_SOURCES, **replacements))
 
 
 def _first_csv_row(path: Path) -> list[str]:

--- a/ics_assessment/tests/test_sync.py
+++ b/ics_assessment/tests/test_sync.py
@@ -2,7 +2,6 @@ import asyncio
 import csv
 import importlib
 import json
-import sys
 import types
 
 import pytest
@@ -71,21 +70,7 @@ def _patch_node_owner_web3(monkeypatch, mod, count, failure_counts):
 
 
 def _load_module():
-    async_web3_stub = types.SimpleNamespace(AsyncHTTPProvider=object)
-
-    class Web3Stub:
-        HTTPProvider = staticmethod(lambda url: url)
-
-        def __init__(self, provider):
-            self.provider = provider
-
-    web3_stub = types.SimpleNamespace(
-        AsyncWeb3=async_web3_stub,
-        Web3=Web3Stub,
-    )
-    sys.modules.setdefault("web3", web3_stub)
-    sys.modules.pop("ics_assessment.sync", None)
-    return importlib.import_module("ics_assessment.sync")
+    return importlib.reload(importlib.import_module("ics_assessment.sync"))
 
 
 def test_expand_targets_all_dedupes():
@@ -96,7 +81,7 @@ def test_expand_targets_all_dedupes():
 
 def test_sync_snapshot_writes_votes(monkeypatch, tmp_path):
     mod = _load_module()
-    mod.engagement_jobs.SNAPSHOT_VOTERS_PATH = tmp_path / "snapshot_voters.csv"
+    monkeypatch.setattr(mod.engagement_jobs, "SNAPSHOT_VOTERS_PATH", tmp_path / "snapshot_voters.csv")
 
     calls = {"count": 0}
 
@@ -142,7 +127,7 @@ def test_sync_snapshot_writes_votes(monkeypatch, tmp_path):
 
 def test_sync_galxe_writes_points(monkeypatch, tmp_path):
     mod = _load_module()
-    mod.engagement_jobs.GALXE_LOYALTY_POINTS_PATH = tmp_path / "galxe_loyalty_points.csv"
+    monkeypatch.setattr(mod.engagement_jobs, "GALXE_LOYALTY_POINTS_PATH", tmp_path / "galxe_loyalty_points.csv")
 
     def fake_post(url, json=None, headers=None):
         cursor = json["variables"]["cursor"]
@@ -186,8 +171,8 @@ def test_sync_galxe_writes_points(monkeypatch, tmp_path):
 
 def test_sync_gitpoap_writes_holders(monkeypatch, tmp_path):
     mod = _load_module()
-    mod.engagement_jobs.GITPOAP_EVENTS_PATH = tmp_path / "gitpoap_events.csv"
-    mod.engagement_jobs.GITPOAP_HOLDERS_PATH = tmp_path / "gitpoap_holders.csv"
+    monkeypatch.setattr(mod.engagement_jobs, "GITPOAP_EVENTS_PATH", tmp_path / "gitpoap_events.csv")
+    monkeypatch.setattr(mod.engagement_jobs, "GITPOAP_HOLDERS_PATH", tmp_path / "gitpoap_holders.csv")
     mod.engagement_jobs.GITPOAP_EVENTS_PATH.write_text("ID,Name\n1,evt1\n2,evt2\n")
 
     class FakeSession:
@@ -211,7 +196,7 @@ def test_sync_gitpoap_writes_holders(monkeypatch, tmp_path):
 
 def test_sync_ssv_verified_writes_holders(monkeypatch, tmp_path):
     mod = _load_module()
-    mod.experience_jobs.SSV_VERIFIED_OPERATORS_PATH = tmp_path / "ssv-verified-operators.csv"
+    monkeypatch.setattr(mod.experience_jobs, "SSV_VERIFIED_OPERATORS_PATH", tmp_path / "ssv-verified-operators.csv")
 
     def fake_get(url, timeout=None):
         assert "ssv.network" in url
@@ -244,11 +229,11 @@ def test_write_csv_uses_lf_line_endings(tmp_path):
     assert data == b"Address,VoteCount\n0xabc,1\n"
 
 
-def test_run_sync_requires_configured_rpc_env():
+def test_run_sync_requires_configured_rpc_env(monkeypatch):
     mod = _load_module()
-    mod.MAINNET_RPC_URL = ""
+    monkeypatch.setattr(mod, "MAINNET_RPC_URL", "")
     called = {"value": False}
-    mod.JOBS["aragon"] = lambda: called.__setitem__("value", True)
+    monkeypatch.setitem(mod.JOBS, "aragon", lambda: called.__setitem__("value", True))
 
     try:
         mod.run_sync(["aragon"])
@@ -286,9 +271,9 @@ def test_rpc_chain_id_uses_json_rpc_probe(monkeypatch):
 
 def test_run_sync_verifies_rpc_chain_id(monkeypatch):
     mod = _load_module()
-    mod.MAINNET_RPC_URL = "https://mainnet.example"
+    monkeypatch.setattr(mod, "MAINNET_RPC_URL", "https://mainnet.example")
     called = {"value": False}
-    mod.JOBS["aragon"] = lambda: called.__setitem__("value", True)
+    monkeypatch.setitem(mod.JOBS, "aragon", lambda: called.__setitem__("value", True))
 
     monkeypatch.setattr(
         mod,
@@ -302,9 +287,9 @@ def test_run_sync_verifies_rpc_chain_id(monkeypatch):
 
 def test_run_sync_rejects_wrong_rpc_chain_id(monkeypatch):
     mod = _load_module()
-    mod.MAINNET_RPC_URL = "https://hoodi.example"
+    monkeypatch.setattr(mod, "MAINNET_RPC_URL", "https://hoodi.example")
     called = {"value": False}
-    mod.JOBS["aragon"] = lambda: called.__setitem__("value", True)
+    monkeypatch.setitem(mod.JOBS, "aragon", lambda: called.__setitem__("value", True))
 
     monkeypatch.setattr(
         mod,
@@ -406,12 +391,10 @@ def test_request_performance_report_retries_then_succeeds(monkeypatch):
 
 def test_sync_mainnet_performance_writes_eligible_ids(monkeypatch, tmp_path):
     mod = _load_module()
-    mod.experience_jobs.ELIGIBLE_NODE_OPERATORS_MAINNET_PATH = (
-        tmp_path / "eligible_node_operators_mainnet.json"
-    )
-    mod.experience_jobs.MAINNET_FEE_DISTRIBUTOR_ADDRESS = "0x" + "12" * 20
-    mod.experience_jobs.MAINNET_FEE_DISTRIBUTOR_FROM_BLOCK = 100
-    mod.experience_jobs.MAINNET_CUTOFF_BLOCK = 200
+    monkeypatch.setattr(mod.experience_jobs, "ELIGIBLE_NODE_OPERATORS_MAINNET_PATH", tmp_path / "eligible_node_operators_mainnet.json")
+    monkeypatch.setattr(mod.experience_jobs, "MAINNET_FEE_DISTRIBUTOR_ADDRESS", "0x" + "12" * 20)
+    monkeypatch.setattr(mod.experience_jobs, "MAINNET_FEE_DISTRIBUTOR_FROM_BLOCK", 100)
+    monkeypatch.setattr(mod.experience_jobs, "MAINNET_CUTOFF_BLOCK", 200)
 
     def fake_fetch_cids(w3, address, from_block, to_block):
         assert address == mod.experience_jobs.MAINNET_FEE_DISTRIBUTOR_ADDRESS
@@ -630,9 +613,9 @@ def test_mainnet_activity_qualification_is_permanent():
     assert mod.experience_jobs._historically_active_operator_ids(frames) == {"42"}
 
 
-def test_get_event_logs_splits_range_on_failure():
+def test_get_event_logs_uses_configured_chunks(monkeypatch):
     mod = _load_module()
-    mod.LOG_CHUNK_SIZE = 5
+    monkeypatch.setattr(mod, "LOG_CHUNK_SIZE", 5)
 
     class FakeEvent:
         def __init__(self):
@@ -649,9 +632,9 @@ def test_get_event_logs_splits_range_on_failure():
     assert event.calls == [(0, 4), (5, 9)]
 
 
-def test_get_event_logs_fails_fast_on_connection_error():
+def test_get_event_logs_fails_fast_on_connection_error(monkeypatch):
     mod = _load_module()
-    mod.LOG_CHUNK_SIZE = None
+    monkeypatch.setattr(mod, "LOG_CHUNK_SIZE", None)
 
     class FakeEvent:
         def __init__(self):
@@ -673,9 +656,9 @@ def test_get_event_logs_fails_fast_on_connection_error():
     assert event.calls == [(0, 9)]
 
 
-def test_get_event_logs_logs_http_error_body(capsys):
+def test_get_event_logs_logs_http_error_body(capsys, monkeypatch):
     mod = _load_module()
-    mod.LOG_CHUNK_SIZE = None
+    monkeypatch.setattr(mod, "LOG_CHUNK_SIZE", None)
 
     class FakeEvent:
         def get_logs(self, from_block=None, to_block=None):

--- a/ics_assessment/tests/test_sync_config.py
+++ b/ics_assessment/tests/test_sync_config.py
@@ -1,0 +1,104 @@
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+VARIABLES = (
+    "GNOSIS_RPC_URL",
+    "IPFS_GATEWAY_URL",
+    "MAINNET_RPC_URL",
+    "HOODI_RPC_URL",
+    "MAINNET_ARCHIVE_RPC_URL",
+    "HOODI_ARCHIVE_RPC_URL",
+)
+
+
+@pytest.mark.parametrize("optional", [None, ""])
+def test_missing_and_empty_optional_endpoints_use_defaults(optional):
+    env = {key: value for key, value in os.environ.items() if key not in VARIABLES}
+    env.update(
+        PYTHON_DOTENV_DISABLED="1",
+        MAINNET_RPC_URL="https://mainnet.example",
+        HOODI_RPC_URL="https://hoodi.example",
+    )
+    if optional is not None:
+        env.update(
+            {
+                key: optional
+                for key in (
+                    "GNOSIS_RPC_URL",
+                    "IPFS_GATEWAY_URL",
+                    "MAINNET_ARCHIVE_RPC_URL",
+                    "HOODI_ARCHIVE_RPC_URL",
+                )
+            }
+        )
+    script = (
+        "import json; from ics_assessment import config; "
+        f"print(json.dumps([getattr(config, key) for key in {VARIABLES!r}]))"
+    )
+    values = json.loads(
+        subprocess.check_output(
+            [sys.executable, "-c", script], cwd=ROOT, env=env, text=True
+        )
+    )
+    assert values == [
+        "https://rpc.gnosis.gateway.fm",
+        "https://gateway.pinata.cloud/ipfs",
+        "https://mainnet.example",
+        "https://hoodi.example",
+        "https://mainnet.example",
+        "https://hoodi.example",
+    ]
+
+
+def test_ipfs_override_is_used_by_both_report_downloaders(monkeypatch):
+    from ics_assessment import sync
+    from ics_assessment.experience import sync_hoodi
+
+    urls = []
+
+    class Response:
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return {"report": "fixture"}
+
+    def get(url, **kwargs):
+        urls.append(url)
+        return Response()
+
+    monkeypatch.setattr(
+        sync.experience_jobs, "IPFS_GATEWAY_URL", "https://gateway.example/ipfs"
+    )
+    monkeypatch.setattr(sync_hoodi, "IPFS_GATEWAY_URL", "https://gateway.example/ipfs")
+    monkeypatch.setattr(sync.experience_jobs.requests, "get", get)
+    assert sync.experience_jobs.request_performance_report("CID") == {
+        "report": "fixture"
+    }
+    assert sync_hoodi.request_performance_report("CID") == {"report": "fixture"}
+    assert urls == ["https://gateway.example/ipfs/CID"] * 2
+
+
+def test_ipfs_configuration_trims_trailing_slashes():
+    env = dict(
+        os.environ,
+        PYTHON_DOTENV_DISABLED="1",
+        IPFS_GATEWAY_URL="https://gateway.example/ipfs///",
+    )
+    result = subprocess.check_output(
+        [
+            sys.executable,
+            "-c",
+            "from ics_assessment.config import IPFS_GATEWAY_URL; print(IPFS_GATEWAY_URL)",
+        ],
+        cwd=ROOT,
+        env=env,
+        text=True,
+    )
+    assert result.strip() == "https://gateway.example/ipfs"

--- a/ics_assessment/tests/test_sync_reliability.py
+++ b/ics_assessment/tests/test_sync_reliability.py
@@ -1,0 +1,234 @@
+"""Exercise Circles batching through actual web3 encoding and decoding."""
+
+import json
+
+import pytest
+from web3 import Web3, HTTPProvider
+from web3.exceptions import Web3RPCError
+
+from ics_assessment import sync, config
+
+
+START = 41_502_657
+END = 48_135_713
+HUB = Web3.to_checksum_address("0x" + "12" * 20)
+TRUSTER = Web3.to_checksum_address(config.GROUP_ADDRESS)
+TOPIC = Web3.to_hex(Web3.keccak(text="Trust(address,address,uint256)"))
+
+
+def address(n):
+    return Web3.to_checksum_address(f"0x{n:040x}")
+
+
+def topic_address(addr):
+    return "0x" + addr[2:].lower().zfill(64)
+
+
+def log(block, n, truster=TRUSTER, trustee=None):
+    return {
+        "address": HUB,
+        "topics": [TOPIC, topic_address(truster), topic_address(trustee or address(n))],
+        "data": "0x" + (2**64 - 1).to_bytes(32, "big").hex(),
+        "blockNumber": hex(block),
+        "blockHash": "0x" + block.to_bytes(32, "big").hex(),
+        "transactionHash": "0x" + n.to_bytes(32, "big").hex(),
+        "transactionIndex": "0x0",
+        "logIndex": hex(n),
+        "removed": False,
+    }
+
+
+class RpcFixture:
+    """Fake only HTTP response bytes, retaining actual web3 encoding/decoding."""
+
+    def __init__(self, monkeypatch, limit=None):
+        self.provider = HTTPProvider("https://rpc.example.invalid")
+        self.w3 = Web3(self.provider)
+        self.event = self.w3.eth.contract(address=HUB, abi=sync.HUB_ABI).events.Trust()
+        self.requests = []
+        self.limit = limit
+        self.filter_params = None
+        self.fault = None
+        blocks = [
+            START,
+            START + 9_999,
+            START + 10_000,
+            START + 99_999,
+            START + 100_000,
+            END - 1,
+            END,
+        ]
+        self.logs = [log(b, n) for n, b in enumerate(blocks, 1)]
+        self.logs += [
+            log(START - 1, 8),
+            log(END + 1, 9),
+            log(START + 1, 10, truster=address(999)),
+        ]
+        monkeypatch.setattr(
+            self.provider._request_session_manager, "make_post_request", self.post
+        )
+
+    def post(self, url, data, **kwargs):
+        req = json.loads(data)
+        self.requests.append(req)
+        method, params = req["method"], req["params"]
+        if self.fault and method == "eth_getLogs":
+            return self.fault
+        if method == "eth_chainId":
+            result = "0x64"
+        elif method == "eth_call":
+            if params[0]["to"].lower() == TRUSTER.lower():
+                result = Web3.to_hex(self.w3.codec.encode(["address"], [HUB]))
+            else:
+                owner = address(int(params[0]["to"], 16) + 1000)
+                result = Web3.to_hex(
+                    self.w3.codec.encode(
+                        ["address[]"], [[owner, config.DEFAULT_SAFE_OWNER]]
+                    )
+                )
+        elif method == "eth_newFilter":
+            self.filter_params = params[0]
+            result = "0x1"
+        elif method in ("eth_getLogs", "eth_getFilterLogs"):
+            f = params[0] if method == "eth_getLogs" else self.filter_params
+            start, end = int(f["fromBlock"], 16), int(f["toBlock"], 16)
+            if self.limit and end - start + 1 > self.limit:
+                return json.dumps(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": req["id"],
+                        "error": {
+                            "code": -32062,
+                            "message": "Block range is too large",
+                        },
+                    }
+                ).encode()
+
+            def matches(entry):
+                if not start <= int(entry["blockNumber"], 16) <= end:
+                    return False
+                addresses = (
+                    f["address"] if isinstance(f["address"], list) else [f["address"]]
+                )
+                if entry["address"].lower() not in [
+                    value.lower() for value in addresses
+                ]:
+                    return False
+                for actual, wanted in zip(entry["topics"], f["topics"]):
+                    if wanted is None:
+                        continue
+                    if actual not in (wanted if isinstance(wanted, list) else [wanted]):
+                        return False
+                return True
+
+            result = [entry for entry in reversed(self.logs) if matches(entry)]
+        else:
+            raise AssertionError(f"unexpected RPC method {method}")
+        return json.dumps(
+            {"jsonrpc": "2.0", "id": req["id"], "result": result}
+        ).encode()
+
+    def ranges(self):
+        return [
+            (int(r["params"][0]["fromBlock"], 16), int(r["params"][0]["toBlock"], 16))
+            for r in self.requests
+            if r["method"] == "eth_getLogs"
+        ]
+
+
+def rpc_error(code, message):
+    return json.dumps(
+        {"jsonrpc": "2.0", "id": 1, "error": {"code": code, "message": message}}
+    ).encode()
+
+
+def fetch(rpc, end=END):
+    return sync.get_event_logs(
+        rpc.event, START, end, argument_filters={"truster": TRUSTER}
+    )
+
+
+def setup_circles(monkeypatch, tmp_path, rpc):
+    monkeypatch.setattr(sync, "LOG_CHUNK_SIZE", None)
+
+    def factory(provider):
+        return rpc.w3
+
+    factory.HTTPProvider = lambda url: rpc.provider
+    factory.to_checksum_address = Web3.to_checksum_address
+    factory.to_hex = Web3.to_hex
+    monkeypatch.setattr(sync.humanity_jobs, "Web3", factory)
+    monkeypatch.setattr(sync.humanity_jobs, "GNOSIS_CUTOFF_BLOCK", END)
+    members = tmp_path / "members.csv"
+    monkeypatch.setattr(sync.humanity_jobs, "CIRCLE_GROUP_MEMBERS_PATH", members)
+    monkeypatch.setattr(sync, "_rpc_chain_id", lambda url: 100)
+    return members
+
+
+def test_migration_preserves_indexed_filter_and_decoded_events(monkeypatch):
+    rpc = RpcFixture(monkeypatch)
+    old = rpc.event.create_filter(
+        from_block=START, to_block=END, argument_filters={"truster": TRUSTER}
+    ).get_all_entries()
+    monkeypatch.setattr(sync, "LOG_CHUNK_SIZE", END - START + 1)
+    new = fetch(rpc)
+    assert rpc.filter_params == rpc.requests[-1]["params"][0]
+    order = lambda event: (event.blockNumber, event.logIndex)
+    assert sorted(old, key=order) == sorted(new, key=order)
+    assert len(new) == 7
+    assert {e.blockNumber for e in new} >= {START, END}
+
+
+def test_default_handles_full_round_under_100k_limit(monkeypatch):
+    rpc = RpcFixture(monkeypatch, limit=100_000)
+    monkeypatch.setattr(sync, "LOG_CHUNK_SIZE", None)
+    assert len(fetch(rpc)) == 7
+    assert len(rpc.ranges()) == 664
+    assert max(end - start + 1 for start, end in rpc.ranges()) == 10_000
+
+
+@pytest.mark.parametrize("chunk_size", [None, 10000, 50000])
+def test_circles_cli_writes_the_same_owners_at_the_cutoff(monkeypatch, tmp_path, chunk_size):
+    rpc = RpcFixture(monkeypatch, limit=100_000)
+    members = setup_circles(monkeypatch, tmp_path, rpc)
+    args = [] if chunk_size is None else ["--chunk-size", str(chunk_size)]
+    assert sync.main(args + ["circles"]) == 0
+    assert max(end - start + 1 for start, end in rpc.ranges()) == (chunk_size or 10000)
+    assert members.read_text().splitlines() == [
+        address(n + 1000).lower() for n in range(1, 8)
+    ]
+    assert all(
+        int(r["params"][1], 16) == END
+        for r in rpc.requests
+        if r["method"] == "eth_call"
+    )
+    assert not any(r["method"] == "eth_newFilter" for r in rpc.requests)
+
+
+def test_failed_circles_chunk_does_not_replace_retained_members(monkeypatch, tmp_path):
+    rpc = RpcFixture(monkeypatch)
+    members = setup_circles(monkeypatch, tmp_path, rpc)
+    members.write_text("retained\n")
+    rpc.fault = rpc_error(-32602, "invalid filter")
+    with pytest.raises(Web3RPCError):
+        sync.main(["circles"])
+    assert members.read_text() == "retained\n"
+
+
+def test_raw_logs_use_default_chunks_and_preserve_filters(monkeypatch):
+    rpc = RpcFixture(monkeypatch, limit=100_000)
+    monkeypatch.setattr(sync, "LOG_CHUNK_SIZE", None)
+    logs = sync.get_raw_logs(
+        rpc.w3, {"address": HUB, "topics": [TOPIC, topic_address(TRUSTER)]}, START, END
+    )
+    assert len(logs) == 7
+    assert len(rpc.ranges()) == 664
+    assert all(end - start + 1 <= 10000 for start, end in rpc.ranges())
+
+
+def test_provider_limit_error_propagates_without_retry_or_resizing(monkeypatch):
+    rpc = RpcFixture(monkeypatch, limit=3000)
+    monkeypatch.setattr(sync, "LOG_CHUNK_SIZE", 10000)
+    with pytest.raises(Web3RPCError):
+        fetch(rpc, START + 20000)
+    assert rpc.ranges() == [(START, START + 9999)]


### PR DESCRIPTION
## Description

Three reliability fixes to the ICS assessment sync, found while running round 6.

**1. `sync_circles` now batches its log fetches.** It was the only target using
the stateful filter API (`events.Trust.create_filter(...).get_all_entries()` →
`eth_newFilter` + `eth_getFilterLogs`) and the only one bypassing `_fetch_logs`,
so `--chunk-size` had no effect on it. It asked for 6.6M blocks in a single call
and failed against `rpc.gnosis.gateway.fm`, which caps `eth_getFilterLogs` at
100k — surfacing as either that error or a misleading `filter not found`, since
the endpoint is load-balanced. `get_event_logs` gains an optional
`argument_filters` passthrough (only forwarded when set, so existing callers and
tests are unaffected) and `sync_circles` uses it.

**2. `GNOSIS_RPC_URL` is now configurable.** It was the only endpoint in the
repo with no `os.getenv` override, which made the batch-loading fix unusable in
practice: measured head-to-head on the real Circles `Trust` query over the full
range, Alchemy Gnosis with 10k chunks did 664 requests in 424s returning 48 logs
with **zero failures**, while `rpc.gnosis.gateway.fm` with 100k chunks failed
**67 of 67** requests (43× `-32062 Block range is too large`, 24×
`JSONDecodeError` from malformed responses). That error is not about range at
all: the same endpoint served 6.6M, 1M, 100k and 1k fine while failing 50k, 10k
and 5k. The default is unchanged, so behaviour is identical for anyone not
setting the variable, and `circles` already validates the chain ID via
`_target_rpcs`.

**3. The IPFS gateway is now configurable.** `ipfs.io` was hardcoded in
`experience/sync.py` and `experience/sync_hoodi.py`. It currently answers
**HTTP 429 with `retry-after: 900`** plus a sunset notice — it is moving to a
service-worker-only gateway, so programmatic `GET /ipfs/<cid>` is going away.
`dweb.link` and `w3s.link` share the rate limit and `cloudflare-ipfs.com` is
discontinued; `gateway.pinata.cloud` serves the same content in ~5s. Round 6
needed 147 reports totalling ~38MB and the newest Hoodi report is already
827KB, so this grows every round. `IPFS_GATEWAY_URL` now defaults to Pinata.

### Verification

- `pytest ics_assessment/tests` → **102 passed**, no test files changed.
- `sync circles` re-run at the round-5 cutoff reproduces the committed
  `circle_group_members.csv` **byte-for-byte**, both over the full range and
  with `--chunk-size 100000`, confirming the migration is behaviour-preserving.
- `sync circles` verified end-to-end with `GNOSIS_RPC_URL` pointing at a
  dedicated provider and `--chunk-size 10000`.
- `IPFS_GATEWAY_URL` verified with the default and with an override, including a
  real report download.

### Not included

Two related issues were measured but left out to keep this reviewable:
`_fetch_logs` has no retry and `Web3RPCError` is not an `HTTPError`, so a single
bad backend response propagates through `run_fetch` and aborts the target; and
`run_sync` (`sync.py:303`) has no per-target isolation, so one failure kills all
eleven targets. Happy to add either here or in a follow-up.

## Checklist

- [ ] Appropriate PR labels applied
- [x] Test coverage maintained (`just coverage`)
  - [x] No need to add/update tests
  - [ ] Tests are added/updated
- [x] Documentation maintained
  - [ ] No need to update
  - [x] Updated