### PR TITLE
fix: limit operator strikes

### DIFF
--- a/src/NodeOperatorStrikes.sol
+++ b/src/NodeOperatorStrikes.sol
@@ -31,6 +31,8 @@ contract NodeOperatorStrikes is INodeOperatorStrikes, StepwiseWeightBoost {
 
     uint256 public constant MAX_DESCRIPTION_LENGTH = 1024;
 
+    uint256 public constant MAX_ACTIVE_STRIKES = 48;
+
     // keccak256(abi.encode(uint256(keccak256("NodeOperatorStrikes")) - 1)) & ~bytes32(uint256(0xff))
     bytes32 private constant NODE_OPERATOR_STRIKES_STORAGE_LOCATION =
         0x510f8e4bbf34090117edc1d950679ffb8abd223dc216175d997628968b892400;
@@ -59,6 +61,7 @@ contract NodeOperatorStrikes is INodeOperatorStrikes, StepwiseWeightBoost {
 
         OperatorStrikes storage rec = _storage().operatorStrikes[input.nodeOperatorId];
         uint256 previousCount = rec.activeIds.length;
+        if (previousCount >= MAX_ACTIVE_STRIKES) revert MaxActiveStrikesReached();
         strikeId = ++rec.lastId;
         rec.activeIds.push(strikeId);
         rec.strikes[strikeId] = Strike({

--- a/src/interfaces/INodeOperatorStrikes.sol
+++ b/src/interfaces/INodeOperatorStrikes.sol
@@ -41,12 +41,16 @@ interface INodeOperatorStrikes is IStepwiseWeightBoost {
     error ZeroLifetime();
     error LifetimeTooLong();
     error InvalidDescription();
+    error MaxActiveStrikesReached();
 
     /// @notice Role allowed to issue and remove strikes.
     function STRIKES_COMMITTEE_ROLE() external view returns (bytes32);
 
     /// @notice Maximum byte length of a strike description.
     function MAX_DESCRIPTION_LENGTH() external view returns (uint256);
+
+    /// @notice Maximum non-removed strikes per operator, including expired strikes.
+    function MAX_ACTIVE_STRIKES() external view returns (uint256);
 
     /// @notice Initialize the provider.
     /// @param admin Address to receive DEFAULT_ADMIN_ROLE.

--- a/test/unit/NodeOperatorStrikes.t.sol
+++ b/test/unit/NodeOperatorStrikes.t.sol
@@ -181,6 +181,47 @@ contract NodeOperatorStrikesIssueTest is NodeOperatorStrikesBaseTest {
         assertEq(strikes.getActiveStrikesCount(NO_ID), 3);
     }
 
+    function test_issueStrike_AllowsCapPerOperator() public {
+        uint256 cap = strikes.MAX_ACTIVE_STRIKES();
+        assertEq(cap, 48);
+        for (uint256 i; i < cap; ++i) assertEq(_issue(NO_ID), i + 1);
+        assertEq(strikes.getActiveStrikesCount(NO_ID), cap);
+        assertEq(_issue(NO_ID + 1), 1);
+    }
+
+    function test_issueStrike_AfterRemovalAtCap() public {
+        uint256 cap = strikes.MAX_ACTIVE_STRIKES();
+        for (uint256 i; i < cap; ++i) _issue(NO_ID);
+
+        vm.prank(committee);
+        strikes.removeStrike(NO_ID, 1);
+
+        assertEq(_issue(NO_ID), cap + 1);
+        assertEq(strikes.getActiveStrikesCount(NO_ID), cap);
+    }
+
+    function test_issueStrike_AfterExpiredRemovalAtCap() public {
+        uint256 cap = strikes.MAX_ACTIVE_STRIKES();
+        for (uint256 i; i < cap; ++i) _issue(NO_ID);
+        vm.warp(block.timestamp + LIFETIME);
+
+        vm.prank(stranger);
+        strikes.removeExpiredStrikes(NO_ID);
+
+        assertEq(strikes.getActiveStrikesCount(NO_ID), 0);
+        assertEq(_issue(NO_ID), cap + 1);
+    }
+
+    function test_issueStrike_RevertWhen_AtCap(bool expired) public {
+        uint256 cap = strikes.MAX_ACTIVE_STRIKES();
+        for (uint256 i; i < cap; ++i) _issue(NO_ID);
+        if (expired) vm.warp(block.timestamp + LIFETIME);
+
+        vm.expectRevert(INodeOperatorStrikes.MaxActiveStrikesReached.selector);
+        vm.prank(committee);
+        strikes.issueStrike(_input(NO_ID, CATEGORY, LIFETIME));
+    }
+
     function test_issueStrike_RevertWhen_NotCommittee() public {
         expectRoleRevert(stranger, strikes.STRIKES_COMMITTEE_ROLE());
         vm.prank(stranger);


### PR DESCRIPTION
## Description

Fix too much expired strikes to remove

## Checklist

- [x] Appropriate PR labels applied
- [x] Test coverage maintained (`just coverage`)
  - [x] Tests are added/updated
- [x] Documentation maintained
  - [x] No need to update
